### PR TITLE
Fix wrong time cut

### DIFF
--- a/php_includes/templates/cells/tempCut.php
+++ b/php_includes/templates/cells/tempCut.php
@@ -1,11 +1,15 @@
 <td>
-    <?php if (isset($data['cut'])) { ?>
+    <?php if (isset($data['cut'])) {
+        $timeCutDisplay = $data['cut'];
+        if (substr($timeCutDisplay, 0, 1) == "0") {
+            $timeCutDisplay = substr($timeCutDisplay, 2);
+        } ?>
         <span class="time-cut">
             <?php
             if ($data['prev_lien'] == '') {
-                echo "-" . $data['cut'];
+                echo "-" . $timeCutDisplay;
             } else {
-                echo "<a href=" . $data['prev_lien'] . " target='_blank' rel='noopener'>-" . $data['cut'];
+                echo "<a href=" . $data['prev_lien'] . " target='_blank' rel='noopener'>-" . $timeCutDisplay;
             ?>
         </span>
     <?php } ?></a>

--- a/php_scripts/db_requests.php
+++ b/php_scripts/db_requests.php
@@ -66,7 +66,7 @@ ORDER BY c.id_track
 $getAllByPlayer = $bdd->prepare('SELECT *
 ,RIGHT(duree, LENGTH(duree) - 4) AS time_record
 ,(
-	SELECT RIGHT(TIMEDIFF(r.time_record, b.duree), LENGTH(b.duree) - 6)
+	SELECT RIGHT(TIMEDIFF(r.time_record, b.duree), LENGTH(b.duree) - 4)
 	FROM record r
 	WHERE b.duree < r.time_record
 		AND r.type_record = b.type_record
@@ -117,7 +117,7 @@ ORDER BY date_record
 $getBKTByPlayer = $bdd->prepare('SELECT *
 ,RIGHT(duree, LENGTH(duree) - 4) AS time_record
 ,(
-	SELECT RIGHT(TIMEDIFF(r.time_record, b.duree), LENGTH(b.duree) - 6)
+	SELECT RIGHT(TIMEDIFF(r.time_record, b.duree), LENGTH(b.duree) - 4)
 	FROM record r
 	WHERE b.duree < r.time_record
 		AND r.type_record = b.type_record
@@ -216,7 +216,7 @@ WHERE id_record IN (
 $getAllTASBKT = $bdd->prepare('SELECT *
 ,RIGHT(duree, LENGTH(duree) - 4) AS time_record
 ,(
-	SELECT RIGHT(TIMEDIFF(r.time_record, b.duree), LENGTH(b.duree) - 6)
+	SELECT RIGHT(TIMEDIFF(r.time_record, b.duree), LENGTH(b.duree) - 4)
 	FROM record r
 	WHERE b.duree < r.time_record
 		AND r.type_record = b.type_record
@@ -266,7 +266,7 @@ ORDER BY date_record DESC
 $getAllByTrackAndCategory = $bdd->prepare('SELECT *
 ,RIGHT(duree, LENGTH(duree) - 4) AS time_record
 ,(
-	SELECT RIGHT(TIMEDIFF(r.time_record, b.duree), LENGTH(b.duree) - 6)
+	SELECT RIGHT(TIMEDIFF(r.time_record, b.duree), LENGTH(b.duree) - 4)
 	FROM record r
 	WHERE b.duree < r.time_record
 		AND r.type_record = b.type_record
@@ -549,7 +549,7 @@ GROUP BY j.name_player
 $getAllSnapshot = $bdd->prepare('SELECT *
 ,RIGHT(duree, LENGTH(duree) - 4) AS time_record
 ,(
-	SELECT RIGHT(TIMEDIFF(r1.time_record, b.duree), LENGTH(b.duree) - 6)
+	SELECT RIGHT(TIMEDIFF(r1.time_record, b.duree), LENGTH(b.duree) - 4)
 	FROM record r1
 	WHERE b.duree < r1.time_record
 		AND r1.type_record = b.type_record


### PR DESCRIPTION
- db_requests now get the time cut (max 9:99.999)
- In php, if time cut is >= 1:00.000, it is displayed, otherwise the first two characters are cut ( e.g. 05.875 instead of 0:05.875)